### PR TITLE
Introducing a new flag: sat_ignore_missing_needs_publish_attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,13 +220,14 @@ Role Variables
 | `sat_excluded_composite_content_views`                       | unset                  | false    | Exclude Composite Content Views from any activity                                  |
 | `sat_excluded_content_views`                                 | unset                  | false    | Exclude Content Views from any activity                                            |
 | `sat_excluded_repositories`                                  | unset                  | false    | Exclude Repositories from any activity/checks                                      |
-| `sat_wait_for_repository_synchronization`                    | `false`                | false    | Whether to wait for Repositories to finish synchronizing                           | 
+| `sat_ignore_missing_needs_publish_attribute`                 | `false`                | false    | Ignore a missing `needs_publish` attribute [^needs_publish]                        |
 | `sat_publish_based_on_repository`                            | unset                  | false    | Whether to publish Content Views based on Repository synchronization date          |
 | `sat_publish_based_on_component`                             | unset                  | false    | Whether to publish Composite Content Views based on their included Components      |
 | `sat_show_summary`                                           | `true`                 | false    | Whether to show a summary at the end of the role, which lists all changed objects  |
 | `sat_skip_legacy_conversion`                                 | `false`                | false    | Whether to skip the on-the-fly conversion of 'legacy' CV/CCV definitions           |
 | `sat_skip_legacy_assert`                                     | `false`                | false    | Disable check if a legacy format can be converted                                  |
 | `sat_skip_assert`                                            | `false`                | false    | Whether to skip the assert statements which check all variables (`assert.yml`)     |
+| `sat_wait_for_repository_synchronization`                    | `false`                | false    | Whether to wait for Repositories to finish synchronizing                           | 
 | `sat_synchronize_repositories`                               | `false`                | false    | Whether to synchronize Repositories prior to publishing                            |
 | `sat_convert_yaml_file`                                      | unset                  | false    | File in which the converted YAML definition will be written to (if requested)      |
 | `sat_convert_yaml_indent`                                    | `2`                    | false    | What indentation (number of spaces) the converted YAML should have                 |
@@ -241,6 +242,12 @@ Role Variables
 
 [^content_view_kinds]: This variable can either have the value `content_views` to process only Content Views, `composite_content_views` to process only Composite Content Views or `both`
                        to process either of them. This way you can limit the activities to either Content Views or Composite Content Views, should you need to do so.
+
+[^needs_publish]: When no action has been performed for a longer timeframe (I don't know the exact timeframe), the `needs_publish` attribute is empty (`null`) for Composite Content Views.
+                  By default, this role will display an error that the `needs_publish` attribute is not defined. When enabling the variable `sat_ignore_missing_needs_publish_attribute`
+                  Composite Content Views that do not have the `needs_publish` attribute, or have it set to `null` will be added to those Composite Content Views that need publishing. This
+                  effectively disables 'Component Based Publishing' for these Composite Content Views. All other Composite Content Views with an existing and populated `needs_publishing`
+                  attribute are not affected by this and will be evaluated as usual.
 
 ## Notes
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,6 +90,14 @@ _def_sat_skip_legacy_assert: false
 # verified that your definition of all the variables is correct.
 _def_sat_skip_assert: false
 
+# whether to ignore a missing or unpopulated 'needs_publish' attribute of all Composite Content Views
+# this attribute is usually unpopulated when no action has been performed on the Composite Content View
+# for a longer time
+# when this variable is set to true, it will effectively ignore whether a publish is required and will
+# publish a new Composite Content View version. This only affects those Composite Content Views which
+# have no 'needs_publish' attribute or when it is 'null'
+_def_sat_ignore_missing_needs_publish_attribute: false
+
 #
 # below variables are only used when this role is run with the tag 'convert'
 #

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -464,6 +464,7 @@
     - '_sat_synchronize_repositories'
     - '_sat_publish_based_on_component'
     - '_sat_show_summary'
+    - '_sat_ignore_missing_needs_publish_attribute'
   loop_control:
     loop_var: '__t_var'
 

--- a/tasks/check_content_view_attr_needs_publish_populated.yml
+++ b/tasks/check_content_view_attr_needs_publish_populated.yml
@@ -51,4 +51,6 @@
             msg: >-
               Above Content Views/Composite Contents Views have not correctly populated the 'needs_publish' attribute.
               It was expected to be of boolean type, so this role cannot safely continue.
+              You can work around an unpopulated 'needs_publish' attribute setting
+              'sat_ignore_missing_needs_publish_attribute' to true.
 ...

--- a/tasks/component_based_publishing.yml
+++ b/tasks/component_based_publishing.yml
@@ -32,17 +32,23 @@
   ansible.builtin.include_tasks:
     file: 'check_content_view_attr_components_populated.yml'
 
-- name: >-
-    component_based_publishing | Include tasks to ensure that all Composite Content Views
-    define the needs_publish attribute
-  ansible.builtin.include_tasks:
-    file: 'check_content_view_attr_needs_publish.yml'
+- name: 'component_based_publishing | Block: Handle needs_publish attribute'
+  when: >-
+    _sat_ignore_missing_needs_publish_attribute is not defined
+    or not _sat_ignore_missing_needs_publish_attribute
+  block:
 
-- name: >-
-    component_based_publishing | Include tasks to ensure that all Composite Content Views
-    populate the needs_publish attribute
-  ansible.builtin.include_tasks:
-    file: 'check_content_view_attr_needs_publish_populated.yml'
+    - name: >-
+        component_based_publishing | Include tasks to ensure that all Composite Content Views
+        define the needs_publish attribute
+      ansible.builtin.include_tasks:
+        file: 'check_content_view_attr_needs_publish.yml'
+
+    - name: >-
+        component_based_publishing | Include tasks to ensure that all Composite Content Views
+        populate the needs_publish attribute
+      ansible.builtin.include_tasks:
+        file: 'check_content_view_attr_needs_publish_populated.yml'
 
 - name: 'component_based_publishing | Collect Composite Content Views that require publishing'
   ansible.builtin.set_fact:
@@ -53,7 +59,30 @@
         selectattr('needs_publish', '==', true)
       }}
 
-- name: 'component_based_publishing | Debug: __t_composite_content_view_publish_requiredi (names only)'
+- name: 'component_based_publishing | Block: Handle ignoring of the needs_publish attribute'
+  when:
+    - '_sat_ignore_missing_needs_publish_attribute is defined'
+    - '_sat_ignore_missing_needs_publish_attribute'
+  block:
+
+    - name: 'component_based_publishing | Set variable with a null value to compare to in the next task'
+      ansible.builtin.set_fact:
+        # this needs to be unquoted. otherwise it is interpreted as string and therefore it will not
+        # match when collecting null-value needs_publish Composite Content Views
+        __t_null: null
+
+    - name: >-
+        component_based_publishing | Add all Composite Content Views that have not defined the needs_publish attribute
+      ansible.builtin.set_fact:
+        __t_composite_content_view_publish_required: >-
+          {{
+            __t_composite_content_view_publish_required |
+            default([]) +
+            __t_excluded_content_views |
+            selectattr('needs_publish', '==', __t_null)
+          }}
+
+- name: 'component_based_publishing | Debug: __t_composite_content_view_publish_required (names only)'
   ansible.builtin.debug:
     var: >-
         __t_composite_content_view_publish_required | map(attribute='name')

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -195,6 +195,17 @@ _sat_check_content_views_known: '{{ sat_check_content_views_known | default(_def
 # Repositories (if any)
 _sat_show_summary: '{{ sat_show_summary | default(_def_sat_show_summary) }}'
 
+# whether to ignore a missing or unpopulated 'needs_publish' attribute of all Composite Content Views
+# this attribute is usually unpopulated when no action has been performed on the Composite Content View
+# for a longer time
+# when this variable is set to true, it will effectively ignore whether a publish is required and will
+# publish a new Composite Content View version. This only affects those Composite Content Views which
+# have no 'needs_publish' attribute or when it is 'null'
+_sat_ignore_missing_needs_publish_attribute: >-
+  {{
+    sat_ignore_missing_needs_publish_attribute | default(_def_sat_ignore_missing_needs_publish_attribute)
+  }}
+
 #
 # below variables are only used when this role is run with the tag 'convert'
 #


### PR DESCRIPTION
This flag essentially ignored a missing or unpopulated (`null`) `needs_publish` attribute of Composite Content Views.

When no action has been performed for a longer timeframe (I don't know the exact timeframe), the `needs_publish` attribute is empty (`null`) for Composite Content Views. By default, this role will display an error that the `needs_publish` attribute is not defined. When enabling the variable `sat_ignore_missing_needs_publish_attribute` Composite Content Views that do not have the `needs_publish` attribute, or have it set to `null` will be added to those Composite Content Views that need publishing. This effectively disables 'Component Based Publishing' for these Composite Content Views. All other Composite Content Views with an existing and populated `needs_publishing` attribute are not affected by this and will be evaluated as usual.