### PR TITLE
Fixing setting of default values for (Composite-) Content View version description

### DIFF
--- a/tasks/check_content_view_attr_needs_publish_populated.yml
+++ b/tasks/check_content_view_attr_needs_publish_populated.yml
@@ -51,6 +51,6 @@
             msg: >-
               Above Content Views/Composite Contents Views have not correctly populated the 'needs_publish' attribute.
               It was expected to be of boolean type, so this role cannot safely continue.
-              You can work around an unpopulated 'needs_publish' attribute setting
+              You can work around an unpopulated 'needs_publish' attribute by setting
               'sat_ignore_missing_needs_publish_attribute' to true.
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -135,7 +135,7 @@
     file: 'prepare.yml'
   vars:
     __t_is_composite: false
-    __t_description: '{{ _sat_content_view_version_description | default(None) }}'
+    __t_given_description: '{{ _sat_content_view_version_description | default(undef()) }}'
     __t_promote_only: '{{ _sat_only_promote_content_views | default(None) }}'
   when:
     - '_sat_content_view_kinds is defined'
@@ -146,7 +146,7 @@
     file: 'prepare.yml'
   vars:
     __t_is_composite: true
-    __t_description: '{{ _sat_composite_content_view_version_description | default(None) }}'
+    __t_given_description: '{{ _sat_composite_content_view_version_description | default(undef()) }}'
     __t_promote_only: '{{ _sat_only_promote_composite_content_views | default(None) }}'
   when:
     - '_sat_content_view_kinds is defined'

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -19,9 +19,9 @@
     # Content View/Composite Content View Version description
     __t_description: >-
       {{
-        __t_description
-        if __t_description is defined
-        and __t_description != None
+        __t_given_description
+        if __t_given_description is defined
+        and __t_given_description != None
         else
         'Patch day ' ~ ansible_date_time.date
       }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -51,14 +51,14 @@ _sat_quiet_assert: '{{ sat_quiet_assert | default(_def_sat_quiet_assert) }}'
 
 # description of the Content View version. This is not the Description of the Content View itself.
 # if unset, it will have the default of 'Patch day YYYY-MM-DD'
-_sat_content_view_version_description: '{{ sat_content_view_version_description | default(None) }}'
+_sat_content_view_version_description: '{{ sat_content_view_version_description | default(undef()) }}'
 
 # description of the Composite Content View version. This is not the Description of the
 # Composite Content View itself.
 # if unset, it will have the default of 'Patch day YYYY-MM-DD'
 _sat_composite_content_view_version_description: >-
   {{
-    sat_composite_content_view_version_description | default(None)
+    sat_composite_content_view_version_description | default(undef())
   }}
 
 # whether to only promote Content Views - no publish will happen.


### PR DESCRIPTION
Fixes https://github.com/sscheib/ansible-role-satellite_publish_promote_content_views/issues/4.

This fixes the default values for `sat_content_view_version_description` and `sat_composite_content_view_version_description`,
which should be by default `Patch day YYYY-mm-dd` if unset.