### PR TITLE
feat: Adding checking for Satellite services

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ This role is absurdly complex. I tested as best as I could, but I certainly cann
 actions *will* change these objects in your Satellite, I'd urge you to test prior to using this in production right away. This role is provided "as is" and I do not take responsibility for any potential
 devastating consequences it might have. Please keep that in mind and test with a snapshot in place for your Satellite or on a lab system. Thanks a lot :slightly_smiling_face:
 
-
-
 This role publishes and optionally promotes both Content View and Composite Content view versions. It makes use of the Red Hat certified
 collection [`redhat.satellite`](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs/).
+
+It is been tested on following Satellite versions:
+
+- 6.15
+- 6.14
+- 6.13
 
 To use the certified collection `redhat.satellite` you need to be a Red Hat subscriber. If you don't own any subscriptions, you can make use of
 [Red Hat's Developer Subscription](https://developers.redhat.com/articles/faqs-no-cost-red-hat-enterprise-linux) which is provided at no cost by Red Hat.

--- a/tasks/check_services.yml
+++ b/tasks/check_services.yml
@@ -1,0 +1,102 @@
+---
+- name: 'check_services | Retrieve Service status of the Satellite'
+  redhat.satellite.status_info:
+    username: >-
+      {{
+        _satellite_username
+        if _satellite_username is defined and _satellite_username != ''
+        else
+        omit
+      }}
+    password: >-
+      {{
+        _satellite_password
+        if _satellite_password is defined and _satellite_password != ''
+        else
+        omit
+      }}
+    server_url: >-
+      {{
+        _satellite_server_url
+        if _satellite_server_url is defined and _satellite_server_url != ''
+        else
+        omit
+      }}
+    validate_certs: >-
+      {{
+        _satellite_validate_certs
+        if _satellite_validate_certs is defined and _satellite_validate_certs | string != ''
+        and _satellite_validate_certs != None
+        else
+        omit
+      }}
+  register: '__t_status'
+
+- name: 'check_services | Ensure Satellite status response is as expected'
+  ansible.builtin.assert:
+    that:
+      # status is defined
+      # - a string
+      # - not empty
+      # - not None
+      - '__t_status.ping.results.katello.status is defined'
+      - '__t_status.ping.results.katello.status is string'
+      - "__t_status.ping.results.katello.status != ''"
+      - "__t_status.ping.results.katello.status != 'None'"
+
+      # services
+      # - is defined
+      # - iterable
+      # - a sequence
+      # - a mapping
+      - '__t_status.ping.results.katello.services is defined'
+      - '__t_status.ping.results.katello.services is iterable'
+      - '__t_status.ping.results.katello.services is sequence'
+      - '__t_status.ping.results.katello.services is mapping'
+    success_msg: 'Satellite status response is as expected'
+    fail_msg: 'The data returned by the Satellite API are not as expected and this role cannot safely continue'
+
+- name: 'check_services | Block: Handle failed services'
+  block:
+
+    - name: 'check_services | Ensure Satellite services are up and running'
+      ansible.builtin.assert:
+        that:
+          # no service reported a failure
+          - >-
+            __t_status.ping.results.katello.services |
+            ansible.builtin.dict2items |
+            rejectattr('value.status', '==', 'ok') |
+            length == 0
+        success_msg: 'Satellite services are up and running'
+        fail_msg: 'One or more Satellite services reported failures'
+
+  rescue:
+
+    - name: 'check_services | List failed services'
+      ansible.builtin.debug:
+        msg: >-
+          {{
+            'Service ' ~
+            __t_service.key ~
+            ' reported status ' ~
+            __t_service.value.status ~
+            ' with message: ' ~
+            __t_service.value.message
+          }}
+      loop: >-
+        {{
+          __t_status.ping.results.katello.services |
+          ansible.builtin.dict2items |
+          selectattr('value.status', '!=', 'ok')
+        }}
+      loop_control:
+        loop_var: '__t_service'
+        label: '{{ __t_service.key }}'
+
+    - name: 'check_services | Fail as Satellite services reported failures'
+      ansible.builtin.fail:
+        msg: >-
+          One or more Satellite services reported failures and this role cannot safely continue. The failed
+          services are listed in the previous task. Please address these failures and re-run the role.
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -108,6 +108,10 @@
     _sat_skip_assert is not defined
     or not _sat_skip_assert
 
+- name: 'Include tasks to check Satellite services'
+  ansible.builtin.include_tasks:
+    file: 'check_services.yml'
+
 - name: 'Gather Ansible date time facts'
   ansible.builtin.setup:
     gather_subset:


### PR DESCRIPTION
Adding an enforced check prior to interacting with the Satellite to ensure Satellite services are up and running and a proper error message is displayed instead of the role failing due to e.g. the Satellite server not being reachable.