### PR TITLE
fix: Ensure CCVs that have not defined needs_publish are collected

### DIFF
--- a/tasks/component_based_publishing.yml
+++ b/tasks/component_based_publishing.yml
@@ -78,8 +78,15 @@
           {{
             __t_composite_content_view_publish_required |
             default([]) +
-            __t_excluded_content_views |
-            selectattr('needs_publish', '==', __t_null)
+            (
+              __t_excluded_content_views |
+              rejectattr('needs_publish', 'undefined') |
+              selectattr('needs_publish', '==', __t_null)
+              +
+              __t_excluded_content_views |
+              selectattr('needs_publish', 'undefined')
+            ) |
+            ansible.builtin.flatten
           }}
 
 - name: 'component_based_publishing | Debug: __t_composite_content_view_publish_required (names only)'


### PR DESCRIPTION
Additionally to 'needs_publish' being 'null' for Composite Content Views that haven't had a task running for a while, it can also happen that 'needs_publish' is not defined altogether.

This commit fixes that.